### PR TITLE
Updated quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ In this guide, we will perform data preperation and machine learning tasks to tr
 
 ## Step-By-Step Guide
 
-For prerequisites, environment setup, step-by-step guide and instructions, please refer to the [QuickStart Guide](https://quickstarts.snowflake.com/guide/getting_started_with_snowpark_for_machine_learning_on_azureml/#0).
+For prerequisites, environment setup, step-by-step guide and instructions, please refer to the [QuickStart Guide](https://quickstarts.snowflake.com/guide/example_matt_marzillo/index.html?index=..%2F..index#0).


### PR DESCRIPTION
The link for the Quickstart Guide throws a `404` error:

![image](https://github.com/Snowflake-Labs/sfguide-getting-started-with-snowpark-for-machine-learning-on-azureml/assets/62304623/b41fce33-e31d-41ad-b246-d5dcd9cfdf55)

I fixed the broken link with [this URL](https://quickstarts.snowflake.com/guide/example_matt_marzillo/index.html?index=..%2F..index#0) from the Snowflake quickstart directory.